### PR TITLE
feat(parser): add support for if expressions

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -30,6 +30,8 @@ lazy_static! {
         terminal!(m, LBrace, "{");
         terminal!(m, RBrace, "}");
         terminal!(m, FnKeyword, "fn");
+        terminal!(m, IfKeyword, "if");
+        terminal!(m, ElseKeyword, "else");
         terminal!(m, ReturnKeyword, "return");
         terminal!(m, Colon, ":");
         terminal!(m, Comma, ",");

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -58,6 +58,14 @@ pub enum Token {
         position: Position,
     },
     #[terminal]
+    IfKeyword {
+        position: Position,
+    },
+    #[terminal]
+    ElseKeyword {
+        position: Position,
+    },
+    #[terminal]
     ReturnKeyword {
         position: Position,
     },
@@ -84,6 +92,8 @@ impl Terminal {
             Terminal::LBrace => Token::LBrace { position },
             Terminal::RBrace => Token::RBrace { position },
             Terminal::FnKeyword => Token::FnKeyword { position },
+            Terminal::IfKeyword => Token::IfKeyword { position },
+            Terminal::ElseKeyword => Token::ElseKeyword { position },
             Terminal::ReturnKeyword => Token::ReturnKeyword { position },
             Terminal::Colon => Token::Colon { position },
             Terminal::Comma => Token::Comma { position },
@@ -110,6 +120,8 @@ impl PartialEq for Token {
                 | (LBrace { .. }, LBrace { .. })
                 | (RBrace { .. }, RBrace { .. })
                 | (FnKeyword { .. }, FnKeyword { .. })
+                | (IfKeyword { .. }, IfKeyword { .. })
+                | (ElseKeyword { .. }, ElseKeyword { .. })
                 | (ReturnKeyword { .. }, ReturnKeyword { .. })
                 | (Colon { .. }, Colon { .. })
                 | (Comma { .. }, Comma { .. })
@@ -135,6 +147,8 @@ impl Token {
             Token::LBrace { position } => *position,
             Token::RBrace { position } => *position,
             Token::FnKeyword { position } => *position,
+            Token::IfKeyword { position } => *position,
+            Token::ElseKeyword { position } => *position,
             Token::ReturnKeyword { position } => *position,
             Token::Colon { position } => *position,
             Token::Comma { position } => *position,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,8 @@ use self::lexer::*;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let input = r#"
-let fnoo = fn(x:void,y:i32):i32{};"#;
+        let a = if x {};
+    "#;
 
     let lexer = Lexer::new(input);
     let lexed = lexer.lex()?;

--- a/src/parser/ast/expression/if_expression.rs
+++ b/src/parser/ast/expression/if_expression.rs
@@ -1,0 +1,157 @@
+use crate::{
+    lexer::Token,
+    parser::{
+        ast::{AstNode, Statement},
+        combinators::Comb,
+        FromTokens,
+    },
+};
+
+use super::Expression;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct If {
+    condition: Box<Expression>,
+    statements: Vec<Statement>,
+    else_statements: Vec<Statement>,
+}
+
+impl FromTokens<Token> for If {
+    fn parse(
+        tokens: &mut crate::lexer::Tokens<Token>,
+    ) -> Result<crate::parser::ast::AstNode, crate::parser::ParseError> {
+        let matcher = Comb::IF_KEYWORD
+            >> Comb::EXPR
+            >> Comb::LBRACE
+            >> (Comb::STATEMENT ^ ())
+            >> Comb::RBRACE;
+
+        let mut result = matcher.parse(tokens)?.into_iter().peekable();
+
+        let Some(AstNode::Expression(condition)) = result.next() else {
+            unreachable!()
+        };
+
+        let mut statements = vec![];
+
+        while let Some(AstNode::Statement(statement)) =
+            result.next_if(|item| matches!(item, AstNode::Statement(_)))
+        {
+            statements.push(statement);
+        }
+
+        let matcher =
+            !(Comb::ELSE_KEYWORD >> Comb::LBRACE >> (Comb::STATEMENT ^ ()) >> Comb::RBRACE);
+
+        let mut result = matcher.parse(tokens)?.into_iter().peekable();
+
+        let mut else_statements = vec![];
+
+        while let Some(AstNode::Statement(statement)) =
+            result.next_if(|item| matches!(item, AstNode::Statement(_)))
+        {
+            else_statements.push(statement);
+        }
+
+        Ok(If {
+            condition: Box::new(condition),
+            statements,
+            else_statements,
+        }
+        .into())
+    }
+}
+
+impl From<If> for AstNode {
+    fn from(value: If) -> Self {
+        AstNode::If(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        lexer::Lexer,
+        parser::ast::{Id, Num},
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_simple_if() {
+        let mut tokens = Lexer::new("if x {}").lex().expect("should work").into();
+
+        assert_eq!(
+            Ok(If {
+                condition: Box::new(Expression::Id(Id("x".into()))),
+                statements: vec![],
+                else_statements: vec![]
+            }
+            .into()),
+            If::parse(&mut tokens)
+        )
+    }
+
+    #[test]
+    fn test_simple_if_else() {
+        let mut tokens = Lexer::new("if x {} else {}")
+            .lex()
+            .expect("should work")
+            .into();
+
+        assert_eq!(
+            Ok(If {
+                condition: Box::new(Expression::Id(Id("x".into()))),
+                statements: vec![],
+                else_statements: vec![]
+            }
+            .into()),
+            If::parse(&mut tokens)
+        )
+    }
+
+    #[test]
+    fn test_complexer_if() {
+        let mut tokens = Lexer::new("if x { 3 + 4 }")
+            .lex()
+            .expect("should work")
+            .into();
+
+        assert_eq!(
+            Ok(If {
+                condition: Box::new(Expression::Id(Id("x".into()))),
+                statements: vec![Statement::Expression(Expression::Addition(
+                    Box::new(Expression::Num(Num(3))),
+                    Box::new(Expression::Num(Num(4)))
+                ))],
+                else_statements: vec![]
+            }
+            .into()),
+            If::parse(&mut tokens)
+        )
+    }
+
+    #[test]
+    fn test_complexer_if_else() {
+        let mut tokens = Lexer::new("if x { 3 + 4 } else { 42 + 1337 }")
+            .lex()
+            .expect("should work")
+            .into();
+
+        assert_eq!(
+            Ok(If {
+                condition: Box::new(Expression::Id(Id("x".into()))),
+                statements: vec![Statement::Expression(Expression::Addition(
+                    Box::new(Expression::Num(Num(3))),
+                    Box::new(Expression::Num(Num(4)))
+                ))],
+                else_statements: vec![Statement::Expression(Expression::Addition(
+                    Box::new(Expression::Num(Num(42))),
+                    Box::new(Expression::Num(Num(1337)))
+                ))],
+            }
+            .into()),
+            If::parse(&mut tokens)
+        )
+    }
+}

--- a/src/parser/ast/mod.rs
+++ b/src/parser/ast/mod.rs
@@ -12,5 +12,6 @@ pub enum AstNode {
     Statement(Statement),
     Initialization(Initialization),
     Function(Function),
+    If(If),
     Parameter(Parameter),
 }

--- a/src/parser/ast/statement/mod.rs
+++ b/src/parser/ast/statement/mod.rs
@@ -12,6 +12,7 @@ use super::{AstNode, Expression};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Statement {
     Initialization(Initialization),
+    Expression(Expression),
     Return(Expression),
 }
 
@@ -41,10 +42,17 @@ impl FromTokens<Token> for Statement {
                 };
                 Ok(Statement::Return(expr.clone()).into())
             }
-            token => Err(ParseError {
-                message: format!("Unexpected token {token:?} while trying to parse Statement"),
-                position: Some(token.position()),
-            }),
+            token => {
+                let matcher = Comb::EXPR;
+                let result = matcher.parse(tokens).map_err(|_| ParseError {
+                    message: format!("Unexpected token {token:?} while trying to parse Statement"),
+                    position: Some(token.position()),
+                })?;
+                let [AstNode::Expression(expr)] = result.as_slice() else {
+                    unreachable!()
+                };
+                Ok(Statement::Expression(expr.clone()).into())
+            }
         }
     }
 }

--- a/src/parser/combinators.rs
+++ b/src/parser/combinators.rs
@@ -3,7 +3,7 @@ use std::ops::{BitOr, BitXor, Not, Shr};
 use crate::lexer::{Terminal, Token, Tokens};
 
 use super::{
-    ast::{AstNode, Expression, Function, Id, Initialization, Num, Parameter, Statement},
+    ast::{AstNode, Expression, Function, Id, If, Initialization, Num, Parameter, Statement},
     FromTokens, ParseError,
 };
 
@@ -156,6 +156,10 @@ impl<'a> Comb<'a, Token, Terminal, AstNode> {
 
     terminal_comb!(FN_KEYWORD, FnKeyword);
 
+    terminal_comb!(IF_KEYWORD, IfKeyword);
+
+    terminal_comb!(ELSE_KEYWORD, ElseKeyword);
+
     terminal_comb!(RETURN_KEYWORD, ReturnKeyword);
 
     terminal_comb!(COLON, Colon);
@@ -175,6 +179,8 @@ impl<'a> Comb<'a, Token, Terminal, AstNode> {
     node_comb!(INITIALIZATION, Initialization);
 
     node_comb!(FUNCTION, Function);
+
+    node_comb!(IF, If);
 
     node_comb!(PARAMETER, Parameter);
 }


### PR DESCRIPTION
The parser now has support for if expression. If expressions consist of an 'if' and an optional 'else' branch, both containing an arbitrary amount of statements.

```
let foo = if x {
  3 + 4
} else {
  42 + 1337
};
```

Furthermore, expressions are now valid statements.