### PR TITLE
feat(lang): rename Pesca to Y

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "pesca-lang"
+name = "y-lang"
 version = "0.1.0"
 edition = "2024"
 authors = ["Louis Meyer (H1ghBre4k3r) <h1ghbe4k3r@dev.bre4k3r.de>"]
 license = "GPL-3.0"
 readme = "README.md"
-repository = "https://github.com/H1ghBre4k3r/pesca-parser"
+repository = "https://github.com/H1ghBre4k3r/y-lang"
 
 [workspace]
 members = ["crates/why_lib", "crates/lex_derive"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pesca Lang
+# Y Lang
 
 > **Attention:** Everything in this project is subject to change! The documentation of the code is nearly non-existent. Furthermore, the currently executable does nothing really useful.
 

--- a/crates/lex_derive/Cargo.toml
+++ b/crates/lex_derive/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Louis Meyer (H1ghBre4k3r) <h1ghbe4k3r@dev.bre4k3r.de>"]
 license = "GPL-3.0"
 readme = "README.md"
-repository = "https://github.com/H1ghBre4k3r/pesca-parser"
+repository = "https://github.com/H1ghBre4k3r/y-parser"
 description = "Some derive macros for creating a lexer"
 
 [lib]

--- a/crates/lex_derive/README.md
+++ b/crates/lex_derive/README.md
@@ -1,3 +1,3 @@
-# Pesca Parser Derive
+# Y Parser Derive
 
 > TBD

--- a/crates/why_lib/Cargo.toml
+++ b/crates/why_lib/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Louis Meyer (H1ghBre4k3r) <h1ghbe4k3r@dev.bre4k3r.de>"]
 license = "GPL-3.0"
 readme = "README.md"
-repository = "https://github.com/H1ghBre4k3r/pesca-parser"
+repository = "https://github.com/H1ghBre4k3r/y-parser"
 
 [dependencies]
 anyhow = "1.0.99"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,6 +1,6 @@
 # Summary
 
-[The Y Programming Language](./pesca-lang.md)
+[The Y Programming Language](./y-lang.md)
 [Prerequisites](./prerequisites.md)
 
 - [Language Basics](./basics/README.md)

--- a/docs/src/basics/README.md
+++ b/docs/src/basics/README.md
@@ -1,3 +1,3 @@
 # Language Basics
 
-Pesca follows the foundations of many other programming languages. This chapter tries to make you familiar with these and provide you with some examples.
+Y follows the foundations of many other programming languages. This chapter tries to make you familiar with these and provide you with some examples.

--- a/docs/src/prerequisites.md
+++ b/docs/src/prerequisites.md
@@ -3,15 +3,15 @@
 At the current stage, the language only exists as a "theoretical concept", since the only stable (and somewhat working) components are the lexer and the parser. Due to that, the only pre-requisites for "using" the language are a working machine, terminal access with Rust and Git installed and available. First, clone the repository:
 
 ```sh
-git clone https://github.com/H1ghBre4k3r/pesca-lang.git
-cd pesca-lang
+git clone https://github.com/H1ghBre4k3r/y-lang.git
+cd y-lang
 ```
 
 After that, you can just build and use the executable:
 
 ```sh
 cargo build --release
-./target/release/pesca-lang <FILE_NAME>
+./target/release/y-lang <FILE_NAME>
 ```
 
 This will print you the lexed tokens, as well as the parse AST.

--- a/docs/src/y-lang.md
+++ b/docs/src/y-lang.md
@@ -4,4 +4,4 @@ _by H1ghBre4k3r._
 
 This text is meant as a basic guide to the Y Programming Language. I want to introduce you to the foundations and concepts of the language, as well as give you some orientation on what to build with it.
 
-If you happen to find and issues within this documentation, feel free to open an issue in the [official repository](https://github.com/H1ghBre4k3r/pesca-lang/issues).
+If you happen to find and issues within this documentation, feel free to open an issue in the [official repository](https://github.com/H1ghBre4k3r/y-lang/issues).

--- a/src/bin/yc.rs
+++ b/src/bin/yc.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use pesca_lang::{VCArgs, compile_file};
+use y_lang::{VCArgs, compile_file};
 
 fn main() -> Result<()> {
     let args = VCArgs::init();


### PR DESCRIPTION
# Rename Pesca to Y

This commit renames the Pesca programming language to Y. The changes
include updating the crate names, file names, and documentation to
reflect the new name. The most important changes are:

- Rename the crate from `pesca-lang` to `y-lang`
- Rename the repository from `pesca-parser` to `y-lang`
- Update all references to "Pesca" to "Y"
- Update the Cargo.toml and Cargo.lock files accordingly