### PR TITLE
feat(yfmt): Implement command-line interface for the formatter

### DIFF
--- a/src/bin/yfmt.rs
+++ b/src/bin/yfmt.rs
@@ -1,0 +1,45 @@
+use std::fs;
+
+use clap::Parser;
+use why_lib::{formatter, lexer::Lexer, parser::parse};
+
+#[derive(clap::Parser, Debug, serde::Serialize, serde::Deserialize)]
+#[command(author, version, about)]
+#[command(propagate_version = true)]
+struct YFmtArgs {
+    /// The path to the source file.
+    #[arg(index = 1)]
+    pub file: std::path::PathBuf,
+
+    /// Whether the edit should be done in place.
+    #[arg(short = 'i', long)]
+    pub in_place: bool,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = YFmtArgs::parse();
+
+    let input = fs::read_to_string(&args.file)?;
+
+    let lexer = Lexer::new(&input);
+    let tokens = lexer.lex()?;
+
+    let statements = match parse(&mut tokens.into()) {
+        Ok(stms) => stms,
+        Err(e) => {
+            eprintln!("{e}");
+            std::process::exit(-1);
+        }
+    };
+
+    let formatted = formatter::format_program(&statements)
+        .map_err(|e| anyhow::anyhow!("Formatting error: {}", e))?;
+
+    if args.in_place {
+        fs::write(&args.file, formatted)?;
+    } else {
+        println!("{formatted}");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Adds a command-line interface for the `why_lib` formatter using the `clap`
crate. Users can now specify a source file path and an optional flag to
edit the file in-place. The formatter reads the input, parses the tokens,
and writes the formatted output to the specified file or prints it to
stdout.