### PR TITLE
feat: Add directory formatting support to yfmt

### DIFF
--- a/src/bin/yfmt.rs
+++ b/src/bin/yfmt.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 
 use clap::Parser;
 use why_lib::{formatter, lexer::Lexer, parser::parse};
@@ -7,9 +8,9 @@ use why_lib::{formatter, lexer::Lexer, parser::parse};
 #[command(author, version, about)]
 #[command(propagate_version = true)]
 struct YFmtArgs {
-    /// The path to the source file.
+    /// The path to the source file or directory to format.
     #[arg(index = 1)]
-    pub file: std::path::PathBuf,
+    pub path: std::path::PathBuf,
 
     /// Whether the edit should be done in place.
     #[arg(short = 'i', long)]
@@ -19,7 +20,23 @@ struct YFmtArgs {
 fn main() -> anyhow::Result<()> {
     let args = YFmtArgs::parse();
 
-    let input = fs::read_to_string(&args.file)?;
+    if args.path.is_file() {
+        format_file(&args.path, args.in_place)?;
+    } else if args.path.is_dir() {
+        format_directory(&args.path, args.in_place)?;
+    } else {
+        eprintln!(
+            "Error: {} is neither a file nor a directory",
+            args.path.display()
+        );
+        std::process::exit(-1);
+    }
+
+    Ok(())
+}
+
+fn format_file(file_path: &Path, in_place: bool) -> anyhow::Result<()> {
+    let input = fs::read_to_string(file_path)?;
 
     let lexer = Lexer::new(&input);
     let tokens = lexer.lex()?;
@@ -27,19 +44,60 @@ fn main() -> anyhow::Result<()> {
     let statements = match parse(&mut tokens.into()) {
         Ok(stms) => stms,
         Err(e) => {
-            eprintln!("{e}");
-            std::process::exit(-1);
+            eprintln!("Parse error in {}: {}", file_path.display(), e);
+            return Ok(()); // Continue processing other files
         }
     };
 
     let formatted = formatter::format_program(&statements)
-        .map_err(|e| anyhow::anyhow!("Formatting error: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Formatting error in {}: {}", file_path.display(), e))?;
 
-    if args.in_place {
-        fs::write(&args.file, formatted)?;
+    if in_place {
+        fs::write(file_path, formatted)?;
+        println!("Formatted: {}", file_path.display());
     } else {
         println!("{formatted}");
     }
 
+    Ok(())
+}
+
+fn format_directory(dir_path: &Path, in_place: bool) -> anyhow::Result<()> {
+    let why_files = collect_why_files(dir_path)?;
+
+    if why_files.is_empty() {
+        println!("No .why files found in {}", dir_path.display());
+        return Ok(());
+    }
+
+    for file_path in why_files {
+        if let Err(e) = format_file(&file_path, in_place) {
+            eprintln!("Error formatting {}: {}", file_path.display(), e);
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_why_files(dir_path: &Path) -> anyhow::Result<Vec<std::path::PathBuf>> {
+    let mut why_files = Vec::new();
+    collect_why_files_recursive(dir_path, &mut why_files)?;
+    Ok(why_files)
+}
+
+fn collect_why_files_recursive(
+    dir_path: &Path,
+    why_files: &mut Vec<std::path::PathBuf>,
+) -> anyhow::Result<()> {
+    for entry in fs::read_dir(dir_path)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path.is_dir() {
+            collect_why_files_recursive(&path, why_files)?;
+        } else if path.extension().and_then(|s| s.to_str()) == Some("why") {
+            why_files.push(path);
+        }
+    }
     Ok(())
 }


### PR DESCRIPTION
This change adds the ability to format all .why files in a directory
recursively. The main changes are:

- The `YFmtArgs` struct now accepts a `path` argument that can be a file or
  a directory.
- The `format_file` function has been added to format a single .why file.
- The `format_directory` function has been added to format all .why files in
  a directory recursively.
- The `collect_why_files` and `collect_why_files_recursive` functions have
  been added to find all .why files in a directory.
- The main function now checks if the provided path is a file or a directory
  and calls the appropriate formatting function.

These changes allow users to format an entire directory of .why files with a
single command, making the tool more convenient and useful.