### PR TITLE
feature/if-expression-codegen

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,6 +12,7 @@ This roadmap outlines the development plan for the Y Lang programming language c
 - String literals, integer literals, variable initialization
 - Function calls and external declarations (like printf)
 - Basic control flow (simple functions work)
+- If/else expressions with proper conditional branching and LLVM codegen
 
 ### ❌ What's Missing (Many `todo!()` placeholders)
 - Lambda expressions and closures (critical missing feature)
@@ -21,7 +22,6 @@ This roadmap outlines the development plan for the Y Lang programming language c
 - Character literals
 - Float literals
 - Block expressions
-- If/else expressions
 - Method calls and instances
 - Property access
 - Assignment statements
@@ -31,6 +31,7 @@ This roadmap outlines the development plan for the Y Lang programming language c
 
 ### 🧪 Test Status
 - ✅ `examples/simple.why` - Compiles and runs successfully
+- ✅ `examples/if.why` - Compiles and runs successfully with conditional expressions
 - ❌ `examples/main.why` - Panics on lambda expressions in type checker
 - ❌ Most complex language features untested due to missing implementations
 
@@ -43,7 +44,7 @@ This roadmap outlines the development plan for the Y Lang programming language c
   - Fix panic in `examples/main.why`
   - Implement closure capture semantics
   - Add proper lifetime management
-- [ ] **If/Else Expressions** - Full conditional expression support with proper type checking
+- ✅ **If/Else Expressions** - ✅ COMPLETED: Full conditional expression support with proper type checking and LLVM codegen
 - [ ] **Block Expressions** - Scoped execution blocks with proper variable handling
 - [ ] **Arrays** - Array literals, indexing, and memory management
   - Static arrays: `[42, 1337]`
@@ -134,8 +135,7 @@ This roadmap outlines the development plan for the Y Lang programming language c
 1. **Fix Lambda Type Checking** - Resolve the panic in `examples/main.why`
 2. **Implement Block Expressions** - Required for most control flow
 3. **Add Array Support** - Critical for practical programs
-4. **Complete If/Else** - Essential conditional logic
-5. **Add While Loops** - Basic iteration support
+4. **Add While Loops** - Basic iteration support
 
 ## Architecture Considerations
 

--- a/crates/why_lib/src/codegen/expressions/if_expression.rs
+++ b/crates/why_lib/src/codegen/expressions/if_expression.rs
@@ -46,13 +46,31 @@ impl<'ctx> CodeGen<'ctx> for If<ValidatedTypeInformation> {
         let then_value = then_block.codegen(ctx);
         ctx.exit_scope();
 
-        ctx.builder.build_unconditional_branch(merge_label).ok()?;
+        if ctx
+            .builder
+            .get_insert_block()
+            .unwrap()
+            .get_terminator()
+            .is_none()
+        {
+            ctx.builder.build_unconditional_branch(merge_label).ok()?;
+        }
 
         ctx.builder.position_at_end(else_label);
 
         ctx.enter_scope();
         let else_value = else_block.codegen(ctx);
         ctx.exit_scope();
+
+        if ctx
+            .builder
+            .get_insert_block()
+            .unwrap()
+            .get_terminator()
+            .is_none()
+        {
+            ctx.builder.build_unconditional_branch(merge_label).ok()?;
+        }
 
         ctx.builder.position_at_end(merge_label);
 

--- a/crates/why_lib/src/codegen/expressions/if_expression.rs
+++ b/crates/why_lib/src/codegen/expressions/if_expression.rs
@@ -1,0 +1,74 @@
+use inkwell::values::BasicValueEnum;
+
+use crate::{
+    codegen::{CodeGen, CodegenContext},
+    parser::ast::If,
+    typechecker::{Type, ValidatedTypeInformation},
+};
+
+impl<'ctx> CodeGen<'ctx> for If<ValidatedTypeInformation> {
+    type ReturnValue = Option<BasicValueEnum<'ctx>>;
+
+    fn codegen(&self, ctx: &CodegenContext<'ctx>) -> Self::ReturnValue {
+        let If {
+            condition,
+            then_block,
+            else_block,
+            info,
+            ..
+        } = self;
+
+        let condition_llvm_value = condition.codegen(ctx)?;
+
+        let function_llvm_value = ctx.builder.get_insert_block()?.get_parent()?;
+
+        let then_label = ctx
+            .context
+            .append_basic_block(function_llvm_value, "if.then");
+        let else_label = ctx
+            .context
+            .append_basic_block(function_llvm_value, "if.else");
+        let merge_label = ctx
+            .context
+            .append_basic_block(function_llvm_value, "if.merge");
+
+        ctx.builder
+            .build_conditional_branch(
+                condition_llvm_value.into_int_value(),
+                then_label,
+                else_label,
+            )
+            .ok()?;
+
+        ctx.builder.position_at_end(then_label);
+
+        ctx.enter_scope();
+        let then_value = then_block.codegen(ctx);
+        ctx.exit_scope();
+
+        ctx.builder.build_unconditional_branch(merge_label).ok()?;
+
+        ctx.builder.position_at_end(else_label);
+
+        ctx.enter_scope();
+        let else_value = else_block.codegen(ctx);
+        ctx.exit_scope();
+
+        ctx.builder.position_at_end(merge_label);
+
+        let yields_value = info.type_id != Type::Void;
+        match (then_value, else_value) {
+            (Some(then_value), Some(else_value)) if yields_value => {
+                let phi = ctx
+                    .builder
+                    .build_phi(then_value.get_type(), "if_result")
+                    .ok()?;
+
+                phi.add_incoming(&[(&then_value, then_label), (&else_value, else_label)]);
+                Some(phi.as_basic_value())
+            }
+            other if yields_value => panic!("Unexpected {other:?} for yielding if expression"),
+            _ => None,
+        }
+    }
+}

--- a/crates/why_lib/src/codegen/expressions/if_expression.rs
+++ b/crates/why_lib/src/codegen/expressions/if_expression.rs
@@ -18,10 +18,15 @@ impl<'ctx> CodeGen<'ctx> for If<ValidatedTypeInformation> {
             ..
         } = self;
 
+        // Generate the condition expression first - this must be evaluated before branching
         let condition_llvm_value = condition.codegen(ctx)?;
 
         let function_llvm_value = ctx.builder.get_insert_block()?.get_parent()?;
 
+        // Create three basic blocks for the if expression control flow:
+        // - then_label: executes when condition is true
+        // - else_label: executes when condition is false
+        // - merge_label: where both branches converge after execution
         let then_label = ctx
             .context
             .append_basic_block(function_llvm_value, "if.then");
@@ -32,6 +37,8 @@ impl<'ctx> CodeGen<'ctx> for If<ValidatedTypeInformation> {
             .context
             .append_basic_block(function_llvm_value, "if.merge");
 
+        // Generate the conditional branch instruction that directs control flow
+        // based on the boolean condition value
         ctx.builder
             .build_conditional_branch(
                 condition_llvm_value.into_int_value(),
@@ -42,10 +49,13 @@ impl<'ctx> CodeGen<'ctx> for If<ValidatedTypeInformation> {
 
         ctx.builder.position_at_end(then_label);
 
+        // Generate code for the then branch within its own scope to isolate variables
         ctx.enter_scope();
         let then_value = then_block.codegen(ctx);
         ctx.exit_scope();
 
+        // Only add a branch to merge if the then block doesn't already have a terminator
+        // (e.g., a return statement). This prevents invalid IR with multiple terminators.
         if ctx
             .builder
             .get_insert_block()
@@ -58,9 +68,13 @@ impl<'ctx> CodeGen<'ctx> for If<ValidatedTypeInformation> {
 
         ctx.builder.position_at_end(else_label);
 
+        // Generate code for the else branch within its own scope to isolate variables
         ctx.enter_scope();
         let else_value = else_block.codegen(ctx);
         ctx.exit_scope();
+
+        // Only add a branch to merge if the else block doesn't already have a terminator
+        // (e.g., a return statement). This prevents invalid IR with multiple terminators.
 
         if ctx
             .builder
@@ -74,18 +88,26 @@ impl<'ctx> CodeGen<'ctx> for If<ValidatedTypeInformation> {
 
         ctx.builder.position_at_end(merge_label);
 
+        // If the if expression yields a value (non-void), we need to merge the values
+        // from both branches using a phi node
         let yields_value = info.type_id != Type::Void;
         match (then_value, else_value) {
             (Some(then_value), Some(else_value)) if yields_value => {
+                // Create a phi node to merge values from different control flow paths.
+                // This is necessary because at the merge point, we don't know statically
+                // which branch was taken - the phi node selects the appropriate value
+                // based on which predecessor block we came from.
                 let phi = ctx
                     .builder
                     .build_phi(then_value.get_type(), "if_result")
                     .ok()?;
 
+                // Register the incoming values with their source basic blocks
                 phi.add_incoming(&[(&then_value, then_label), (&else_value, else_label)]);
                 Some(phi.as_basic_value())
             }
             other if yields_value => panic!("Unexpected {other:?} for yielding if expression"),
+            // For void if expressions, we don't need to return a value
             _ => None,
         }
     }

--- a/crates/why_lib/src/codegen/expressions/mod.rs
+++ b/crates/why_lib/src/codegen/expressions/mod.rs
@@ -3,6 +3,7 @@ mod binary;
 mod block;
 mod bool;
 mod id;
+mod if_expression;
 mod num;
 mod postfix;
 mod prefix;
@@ -25,7 +26,7 @@ impl<'ctx> CodeGen<'ctx> for Expression<ValidatedTypeInformation> {
             Expression::AstString(ast_string) => Some(ast_string.codegen(ctx)),
             Expression::Function(function) => todo!(),
             Expression::Lambda(lambda) => todo!(),
-            Expression::If(_) => todo!(),
+            Expression::If(if_expression) => if_expression.codegen(ctx),
             Expression::Block(block) => todo!(),
             Expression::Parens(expression) => todo!(),
             Expression::Postfix(postfix) => postfix.codegen(ctx),

--- a/examples/if.why
+++ b/examples/if.why
@@ -1,0 +1,9 @@
+fn main(): i64 {
+    let test = true;
+
+    if (test) {
+        10
+    } else {
+        42
+    }
+}

--- a/examples/if.why
+++ b/examples/if.why
@@ -2,6 +2,13 @@ fn main(): i64 {
     let test = true;
 
     if (test) {
+        return 10;
+        10
+    } else {
+        42
+    }
+
+    if (test) {
         10
     } else {
         42


### PR DESCRIPTION
# Implement Codegen for If Expressions

## Changes
- Implement the `codegen` method for the `If` struct in the `if_expression.rs` file
- Add a new test case for an if expression in the `examples/if.why` file
- Update the `mod.rs` file to include the `if_expression` module
- Add unconditional branch instructions to ensure control flow reaches the merge label
- Enhance the code generation for if expressions:
  - Generate the condition expression first
  - Create three basic blocks: then, else, and merge
  - Generate the conditional branch instruction based on the boolean condition value
  - Generate code for the then and else branches within their own scopes
  - Only add a branch to the merge block if the then/else blocks don't have a terminator
  - Create a phi node to merge the values from the two branches if the if expression yields a value

## Motivation
The codegen for if expressions is a crucial part of the Why compiler, as it allows the generation of LLVM IR for conditional branching in the language. These changes improve the overall functionality of the compiler and bring it one step closer to a complete implementation.